### PR TITLE
Fix to work with KiCAD 5

### DIFF
--- a/kicad_unified_bom_xyrs.py
+++ b/kicad_unified_bom_xyrs.py
@@ -176,7 +176,7 @@ for module in board.GetModules():
         side = 'bottom' if module.IsFlipped() else 'top'
 
     fpid = module.GetFPID()
-    fp = '{}:{}'.format(fpid.GetLibNickname(), fpid.GetFootprintName())
+    fp = '{}:{}'.format(fpid.GetLibNickname(), fpid.GetLibItemName())
 
     scaling_factor = 1000000.0
     origin_offset = (0, 0)


### PR DESCRIPTION
In the latest KiCAD `GetFootprintName()` has been replaced by
`GetLibItemName()`.

Fixes kylemanna/kicad-utils#3.